### PR TITLE
make min_confidence match Brakeman defaults

### DIFF
--- a/lib/guard/brakeman.rb
+++ b/lib/guard/brakeman.rb
@@ -37,7 +37,7 @@ module Guard
         :notifications => true,
         :run_on_start => false,
         :chatty => false,
-        :min_confidence => 1,
+        :min_confidence => 2,
         :quiet => false
       }.merge!(options)
       @scanner_opts = ::Brakeman::set_options({:app_path => '.'}.merge(@options))


### PR DESCRIPTION
Brakeman defaults to 2, so guard-brakeman should do the same (so the output is the same when running on the command line).