### PR TITLE
Make readme match default template

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please read the [Guard usage documentation](https://github.com/guard/guard#readm
 Guard::Brakeman can be adapted to all kind of projects and comes with a default template that looks like this:
 
 ```ruby
-guard 'brakeman' do
+guard :brakeman, run_on_start: true do
   watch(%r{^app/.+\.(erb|haml|rhtml|rb)$})
   watch(%r{^config/.+\.rb$})
   watch(%r{^lib/.+\.rb$})

--- a/lib/guard/brakeman/templates/Guardfile
+++ b/lib/guard/brakeman/templates/Guardfile
@@ -1,4 +1,4 @@
-guard 'brakeman', :run_on_start => true do
+guard :brakeman, run_on_start: true do
   watch(%r{^app/.+\.(erb|haml|rhtml|rb)$})
   watch(%r{^config/.+\.rb$})
   watch(%r{^lib/.+\.rb$})


### PR DESCRIPTION
The default template was not matching what was in the readme so changed to match and updated ruby syntax.