### PR TITLE
Relative file path for all(?) versions of Brakeman

### DIFF
--- a/lib/guard/brakeman.rb
+++ b/lib/guard/brakeman.rb
@@ -204,13 +204,24 @@ module Guard
       output =  Guard::Compat::UI.color(msg)
       output << " - #{warning.warning_type} - #{warning.message}"
       output << " near line #{warning.line}" if warning.line
-      if warning.file
-        # fix this ish or wait for brakeman to be fixed
-        filename = warning.file.gsub(@options[:app_path], '')
-        output << " in #{filename}"
+
+      if path = relative_warning_path(warning)
+        output << " in #{path}"
       end
+
       output << ": #{warning.format_code}" if warning.code
       output
+    end
+
+    def relative_warning_path warning
+      case
+      when warning.file.nil? # This should never really happen
+        nil
+      when warning.respond_to?(:relative_path) # For Brakeman < 4.5.1
+        warning.relative_path
+      else # Must be new Brakeman::FilePath, Brakeman >= 4.5.1
+        warning.file.relative
+      end
     end
   end
 end


### PR DESCRIPTION
I broke guard-brakeman in Brakeman 4.5.1 when I switched Brakeman from using strings to represent paths internally to `Brakeman::FilePath`.

`Brakeman::Warning#relative_path` has been in Brakeman for a long time, so that *should* be the preferred API. However...I also removed that in 4.5.1. I should not have done that. I will add it back in 4.5.2 (or whatever the next release is).

Even after that, though, it would still leave guard-brakeman incompatible with Brakeman 4.5.1. So this patch will work with 4.5.1 and any other supported version.

I tested with Brakeman 4.5.1, 4.5.0, and 2.1.1.