### PR TITLE
Call Guard::Compat::UI.color with correct arguments

### DIFF
--- a/lib/guard/brakeman.rb
+++ b/lib/guard/brakeman.rb
@@ -203,8 +203,8 @@ module Guard
         :white
       end
 
-      msg = ::Brakeman::Warning::TEXT_CONFIDENCE[warning.confidence], color
-      output =  Guard::Compat::UI.color(msg)
+      msg = ::Brakeman::Warning::TEXT_CONFIDENCE[warning.confidence]
+      output =  Guard::Compat::UI.color(msg, color)
       output << " - #{warning.warning_type} - #{warning.message}"
       output << " near line #{warning.line}" if warning.line
 


### PR DESCRIPTION
Fixes #39

Not 100% sure how this worked previously (since guard-compat has not changed in a long time), but in any case the API is:

```ruby
Guard::Compat::UI.color(msg, *color_opts)
```

Previously this plugin was passing in an array for the `msg`, like `["High", :red]`. Maybe this was meant to be `Guard::Compat::UI.color(*msg)`? In any case, simple change to correct it.

I failed at adding a test 😞 