### PR TITLE
Prep for next release of Brakeman

### DIFF
--- a/lib/guard/brakeman.rb
+++ b/lib/guard/brakeman.rb
@@ -38,7 +38,8 @@ module Guard
         :run_on_start => false,
         :chatty => false,
         :min_confidence => 2,
-        :quiet => false
+        :quiet => false,
+        :support_rescanning => true, # Will be needed for Brakeman 7.0
       }.merge!(options)
       @scanner_opts = ::Brakeman::set_options({:app_path => '.'}.merge(@options))
     end


### PR DESCRIPTION
In the next version of Brakeman, the `support_rescanning` option must be set in order to use the rescanning feature properly.

Fortunately(?), this is totally backwards-compatible because Brakeman doesn't validate options!